### PR TITLE
Add security advisory packages to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,8 +119,10 @@
         "behat/mink-goutte-driver": "^1.2",
         "drupal/coder": "^8.3",
         "drupal/config_devel": "^1.2",
+        "drupal-composer/drupal-security-advisories" : "8.x-dev",
         "drupal/testtools": "^1.0",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5",
+        "roave/security-advisories": "dev-master"
     },
     "scripts": {
         "pre-install-cmd": [


### PR DESCRIPTION
This PR can be only finalized if https://github.com/Pronovix/devportal-drupal-module/pull/59 gets released in a new stable version and `drupal/markdown` also releases a new stable version with a bumped `league/commonmark` version.

Right now this is what I see when I try to install these packages, which is the expected behavior:

```
  Problem 1
    - drupal/devportal 2.0.0-alpha4 requires league/commonmark ^0.15.3 -> satisfiable by league/commonmark[0.15.7, 0.15.3, 0.15.4, 0.15.5, 0.15.6].
    - drupal/devportal 2.0.0-alpha4 requires league/commonmark ^0.15.3 -> satisfiable by league/commonmark[0.15.7, 0.15.3, 0.15.4, 0.15.5, 0.15.6].
    - drupal/devportal 2.0.0-alpha3 requires league/commonmark ^0.15.3 -> satisfiable by league/commonmark[0.15.7, 0.15.3, 0.15.4, 0.15.5, 0.15.6].
    - drupal/devportal 2.0.0-alpha2 requires league/commonmark ^0.15.3 -> satisfiable by league/commonmark[0.15.7, 0.15.3, 0.15.4, 0.15.5, 0.15.6].
    - drupal/devportal 2.0.0-alpha1 requires league/commonmark ^0.15.3 -> satisfiable by league/commonmark[0.15.7, 0.15.3, 0.15.4, 0.15.5, 0.15.6].
    - roave/security-advisories dev-master conflicts with league/commonmark[0.15.3].
    - roave/security-advisories dev-master conflicts with league/commonmark[0.15.4].
    - roave/security-advisories dev-master conflicts with league/commonmark[0.15.5].
    - roave/security-advisories dev-master conflicts with league/commonmark[0.15.6].
    - roave/security-advisories dev-master conflicts with league/commonmark[0.15.7].
    - roave/security-advisories dev-master conflicts with league/commonmark[0.15.7].
    - Installation request for roave/security-advisories dev-master -> satisfiable by roave/security-advisories[dev-master].
    - Installation request for drupal/devportal ^2.0@alpha -> satisfiable by drupal/devportal[2.0.0-alpha4, 2.0.0-alpha3, 2.0.0-alpha2, 2.0.0-alpha1].
```
