### PR TITLE
Add support for bz2 archives for composer

### DIFF
--- a/.gitignore.project
+++ b/.gitignore.project
@@ -72,4 +72,5 @@ docker-compose.override.yml
 
 # Ignore node_modules folders.
 node_modules
-.sass-cache
+
+web/themes/devportal/**/*.css

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,6 +1,7 @@
 FROM amazeeio/php:7.2-cli-drupal
 
-RUN apk add python build-base
+RUN apk add python build-base libc6-compat bzip2 bzip2-dev
+RUN docker-php-ext-install bz2
 COPY composer.json composer.lock /app/
 COPY scripts /app/scripts
 RUN composer install --no-dev


### PR DESCRIPTION
With the change in the Dockerfile, composer can extract tar.bz2
archives.

The project gitignore file contains now style.css (since it is generated
by gulp), and the duplicate .sass-cache entry was fixed.