### PR TITLE
Update instruction to create a new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Start pygmy: `pygmy up`
 ## Create a new project
 
 ``` shell
-docker run --rm -it -v $PWD:/app --user $(id -u):$(id -g) composer \
+docker run --rm -it -v $PWD:/app --user $(id -u):$(id -g) tamasd/composer \
  create-project Pronovix/devportal-starterkit \
- -s dev --ignore-platform-reqs $DEVPORTAL_NAME
+ -s dev $DEVPORTAL_NAME
 ```
 
 This command will create the project files with the containers.


### PR DESCRIPTION
Using `--ignore-platform-reqs` is not wise, since it will cause issues
when setting up the site on an older PHP version (e.g. 7.1). However,
that was originally added, so create-project can run without `gd`
installed.

This is a proper fix, with a composer image that contains gd and the
oldest supported PHP version.